### PR TITLE
Added homework for lecture 5

### DIFF
--- a/code/cabal.project
+++ b/code/cabal.project
@@ -68,9 +68,8 @@ source-repository-package
 -- of plutus-apps are also updated
 source-repository-package
   type: git
-  -- same as for marlowe-pioneers in marlowe-cardano
-  location: https://github.com/paluh/plutus-apps
-  tag: 5bcc67b3b2eb219a54b90c24920a72c9266190a2
+  location: https://github.com/input-output-hk/plutus-apps
+  tag: 3c70df0616195285945992554469da4c74dc2aa2
   subdir:
     freer-extras
     playground-common

--- a/code/cabal.project
+++ b/code/cabal.project
@@ -58,17 +58,19 @@ package cardano-wallet-core-integration
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/marlowe-cardano
-  tag: 452632c2bd2c7368e676ef8f176ba2c916afa0f3
+  tag: 8d1e3f6daacf9fbd3ad4c46ef9b6745954c6843a
   subdir:
     marlowe
+    marlowe-contracts
 
 -- A lot of marlowe dependencies have to be syncronized with the dependencies of
 -- plutus-apps. If you update plutus-apps, please make sure that all dependencies
 -- of plutus-apps are also updated
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/plutus-apps
-  tag: f3278f5d6db2476174985ef5ea851a2dbd57f0b7
+  -- same as for marlowe-pioneers in marlowe-cardano
+  location: https://github.com/paluh/plutus-apps
+  tag: 5bcc67b3b2eb219a54b90c24920a72c9266190a2
   subdir:
     freer-extras
     playground-common

--- a/code/marlowe-pioneer-program.cabal
+++ b/code/marlowe-pioneer-program.cabal
@@ -87,3 +87,25 @@ executable simple-payment-close
   build-depends:
     , base ^>=4.14.3.0
     , marlowe
+
+executable chooser-option
+  default-language: Haskell2010
+  hs-source-dirs:   src/lecture05/homework
+  main-is:          chooser_option.hs
+  ghc-options:      -Wall
+
+  build-depends:
+    , base ^>=4.14.3.0
+    , marlowe
+    , marlowe-contracts
+
+executable cliquet-option
+  default-language: Haskell2010
+  hs-source-dirs:   src/lecture05/homework
+  main-is:          cliquet_option.hs
+  ghc-options:      -Wall
+
+  build-depends:
+    , base ^>=4.14.3.0
+    , marlowe
+    , marlowe-contracts

--- a/code/src/lecture05/homework/chooser_option.hs
+++ b/code/src/lecture05/homework/chooser_option.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Language.Marlowe.Extended
+import Marlowe.Contracts.Options
+
+-- |Chooser option to buy or sell 1000 Ada for 500 DjedUSD with expiry 2022-06-30 17:30
+main :: IO ()
+main = print $ pretty $
+  chooserOption
+    (Role "Buyer")
+    (Role "Seller")
+    Nothing
+    (Token "f4cf384ddd1b1377b08302b17990e9618b62924f5705458c17ee4f7d" "DjedUSD")
+    ada
+    (Constant 500)
+    (Constant 1000)
+    (POSIXTime 1656610200) -- 2022-06-30 17:30:00.000000 UTC
+    (POSIXTime 1656612000) -- 2022-06-30 18:00:00.000000 UTC
+
+-- |A /Chooser Option/ allows the holder of the option to decide prior to the expiration
+-- if the option is a call or put. Strike and expiration date are the same in either case.
+chooserOption ::
+     Party          -- ^ Buyer
+  -> Party          -- ^ Seller
+  -> Maybe ChoiceId -- ^ Price feed for the underlying
+  -> Token          -- ^ Currency
+  -> Token          -- ^ Underlying
+  -> Value          -- ^ Strike price (in currency)
+  -> Value          -- ^ Amount of underlying tokens per contract
+  -> Timeout        -- ^ Maturity
+  -> Timeout        -- ^ Settlement date
+  -> Contract       -- ^ Chooser Option Contract
+chooserOption buyer seller priceFeed currency underlying strike ratio maturity settlement =
+  undefined -- TODO

--- a/code/src/lecture05/homework/cliquet_option.hs
+++ b/code/src/lecture05/homework/cliquet_option.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import Language.Marlowe.Extended
+import Marlowe.Contracts.Options
+
+-- |Cliquet option
+main :: IO ()
+main = print $ pretty $
+  cliquetOption
+    Call
+    (Role "Buyer")
+    (Role "Seller")
+    Nothing
+    (Token "f4cf384ddd1b1377b08302b17990e9618b62924f5705458c17ee4f7d" "DjedUSD")
+    ada
+    (Constant 1000)
+    [ (POSIXTime 1656610200) -- 2022-06-30 17:30:00.000000 UTC
+    , (POSIXTime 1659288600) -- 2022-07-31 17:30:00.000000 UTC
+    , (POSIXTime 1661967000) -- 2022-08-31 17:30:00.000000 UTC
+    ]
+    (POSIXTime 600)          -- 10 minutes
+
+-- |A /Cliquet Option/ consists of a series of consecutive options. The options are executed in sequence, the strike price
+-- of the next option is always the current price of the underlying. The option type can be either Call or Put.
+cliquetOption ::
+     OptionType     -- ^ Type of Option
+  -> Party          -- ^ Buyer
+  -> Party          -- ^ Seller
+  -> Maybe ChoiceId -- ^ Price feed for the underlying
+  -> Token          -- ^ Currency
+  -> Token          -- ^ Underlying
+  -> Value          -- ^ Ratio
+  -> [Timeout]      -- ^ Maturities
+  -> Timeout        -- ^ Settlement delay
+  -> Contract       -- ^ Cliquet Option Contract
+cliquetOption optionType buyer seller priceFeed currency underlying ratio expiries delay =
+  undefined


### PR DESCRIPTION
Added two exercises for the lecture about financial contracts. Both are about building more complex option contracts out of simpler ones. For the _Cliquet Option_ I had to update the `Options` module in `marlowe-contracts` and therefore the revision for `marlowe-cardano` in `cabal.project` has changed. In order to make the project compile again, I had to update `plutus-apps` as well, which I set to same the revision as in the `marlowe-pioneers` branch in `marlowe-cardano`